### PR TITLE
Fix 3rd secondElement definition in patternmatching.json

### DIFF
--- a/app/json/patternmatching.json
+++ b/app/json/patternmatching.json
@@ -93,7 +93,7 @@
     },
     {
       "preparagraph": "Same koan as above, but we are pattern matching of a list with only one item!",
-      "code": "val secondElement = List(1) match {\n  case x :: y :: xs => xs\n  case _ => 0\n}\n\nsecondElement should be(__)",
+      "code": "val secondElement = List(1) match {\n  case x :: y :: xs => y\n  case _ => 0\n}\n\nsecondElement should be(__)",
       "solutions": [
         "0"
       ],


### PR DESCRIPTION
In:

    val secondElement = List(1) match {
      case x :: y :: xs => xs
      case _ => 0
    }

the second line should be:

      case x :: y :: xs => y