### PR TITLE
Update valandvar.json

### DIFF
--- a/app/json/valandvar.json
+++ b/app/json/valandvar.json
@@ -2,7 +2,7 @@
   "title": "Val and Var",
   "modules": [
     {
-      "preparagraph": "Scala allows one to decide whether a variable is immutable or mutable. Immutable is read-only whereas mutable is read-write. Immutable variables are declared with the keyword `val`.\n\n```\nval age:Int = 22\n```\n\nHere age has been initialized to a value during its declaration. As it has been declared as a `val`, age cannot be reassigned to a new value. Any attempt to do will result in a reassignment to `val` error. \n\nMutable variables are declared with the keyword `var`. Unlike val, `var` can be reassigned to different values or point to different objects. But they have to be initialised at the time of declaration.\n\n```\nvar age:Int = 22\nage = 35\n```\n\nThere’s an exception to the rule that one must initialize the `val`’s and `var`’s. When they are used as constructor parameters, the `val`’s and `var`’s will be initialised when the object is instantiated. Also, derived classes can override `val`’s declared inside the parent classes.\n\nYour turn. Remember, `var`'s may be reassigned.",
+      "preparagraph": "Scala allows one to decide whether a variable is immutable or mutable. Immutable is read-only whereas mutable is read-write. Immutable variables are declared with the keyword `val`.\n\n```\nval age:Int = 22\n```\n\nHere age has been initialized to a value during its declaration. As it has been declared as a `val`, age cannot be reassigned to a new value. Any attempt to do will result in a reassignment to `val` error. \n\nMutable variables are declared with the keyword `var`. Unlike val, `var` can be reassigned to different values or point to different objects. But they have to be initialised at the time of declaration.\n\n```\nvar age:Int = 22\nage = 35\n```\n\nThere’s an exception to the rule that one must initialize the `val`’s and `var`’s. When they are used as constructor parameters, the `val`’s and `var`’s will be initialised when the object is instantiated. Also, derived classes can override `val`’s declared inside the parent classes.\n\nYour turn. Remember, `var`'s may be reassigned,",
       "code": "var a = 5\na should be(__)\na = 7\na should be(__)",
       "solutions": [
         "5",
@@ -11,12 +11,12 @@
       "postparagraph": ""
     },
     {
-      "preparagraph": "And `val`'s may not be reassigned",
+      "preparagraph": "but `val`'s may not be reassigned.",
       "code": "val a = 5\na should be(__)\n\n// What happens if you uncomment these lines?\n// a = 7\n// a should be (7)",
       "solutions": [
         "5"
       ],
-      "postparagraph": "Let us consider an Array being declared as `val`.\n\n```\nval stringArray:Array[String] = new Array(6)\n```\n\n  The stringArray can be modified, but the reference cannot be modified to point to another Array.\n\n```\nstringArray = new Array(33)\n```\n\nwill result in a reassignment to val error, but\n\n```\nstringArray(3) = "foo"\n```\n\nwill not result in the error."
-    }
+      "postparagraph": "Remember that `val` does not lock down the internal state of the variable, only its assignment.  Let us consider an Array being declared as `val`.\n\n```\nval stringArray:Array[String] = new Array(6)\n```\nThe `stringArray` can be modified, but the reference cannot be modified to point to another Array.  For example,\n\n```\nstringArray = new Array(33)\n```\nwill result in a reassignment to val error, but\n```\nstringArray(3) = \"foo\"\n```\nwill not result in any error."
+     }
   ]
 }

--- a/app/json/valandvar.json
+++ b/app/json/valandvar.json
@@ -2,7 +2,7 @@
   "title": "Val and Var",
   "modules": [
     {
-      "preparagraph": "Scala allows one to decide whether a variable is immutable or mutable. Immutable is read-only whereas mutable is read-write. Immutable variables are declared with the keyword `val`.\n\n```\nval age:Int = 22\n```\n\nHere age has been initialized to a value during its declaration. As it has been declared as a `val`, age cannot be reassigned to a new value. Any attempt to do will result in al reassignment to `val` error. Let us consider an Array being declared as `val`.\n\nMutable variables are declared with the keyword `var`. Unlike val, `var` can be reassigned to different values or point to different objects. But they have to be initialised at the time of declaration.\n\n```\nvar age:Int = 22\nage = 35\n```\n\nThere’s an exception to the rule that one must initialize the `val`’s and `var`’s. When they are used as constructor parameters, the `val`’s and `var`’s will be initialised when the object is instantiated. Also, derived classes can override `val`’s declared inside the parent classes.\n\nYour turn. Remember, `var`'s may be reassigned.",
+      "preparagraph": "Scala allows one to decide whether a variable is immutable or mutable. Immutable is read-only whereas mutable is read-write. Immutable variables are declared with the keyword `val`.\n\n```\nval age:Int = 22\n```\n\nHere age has been initialized to a value during its declaration. As it has been declared as a `val`, age cannot be reassigned to a new value. Any attempt to do will result in a reassignment to `val` error. \n\nMutable variables are declared with the keyword `var`. Unlike val, `var` can be reassigned to different values or point to different objects. But they have to be initialised at the time of declaration.\n\n```\nvar age:Int = 22\nage = 35\n```\n\nThere’s an exception to the rule that one must initialize the `val`’s and `var`’s. When they are used as constructor parameters, the `val`’s and `var`’s will be initialised when the object is instantiated. Also, derived classes can override `val`’s declared inside the parent classes.\n\nYour turn. Remember, `var`'s may be reassigned.",
       "code": "var a = 5\na should be(__)\na = 7\na should be(__)",
       "solutions": [
         "5",
@@ -16,7 +16,7 @@
       "solutions": [
         "5"
       ],
-      "postparagraph": ""
+      "postparagraph": "Let us consider an Array being declared as `val`.\n\n```\nval stringArray:Array[String] = new Array(6)\n```\n\n  The stringArray can be modified, but the reference cannot be modified to point to another Array.\n\n```\nstringArray = new Array(33)\n```\n\nwill result in a reassignment to val error, but\n\n```\nstringArray(3) = "foo"\n```\n\nwill not result in the error."
     }
   ]
 }


### PR DESCRIPTION
Typo correction in preparagraph 1

>"will result in al reassignment" 
>"will result in a reassignment"

Additional content elaborating on the ability to modify the internal state of a val added.
>"postparagraph": ""
>"postparagraph": "Let us consider an Array being declared as `val`.\n\n```\nval stringArray:Array[String] = new Array(6)\n```\n\n  The stringArray can be modified (the internal state of a val can be changed), but the reference/assignment cannot be modified to point to another Array.\n\n```\nstringArray = new Array(33)\n```\n\nwill result in a reassignment to val error, but\n\n```\nstringArray(3) = "foo"\n```\n\nwill not result in the error."
+    }