### PR TITLE
Issue 59 - Includes wartremover

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,64 +1,69 @@
 import play.PlayImport._
-import play.PlayImport.PlayKeys._
 import sbt.Project.projectToRef
 
 lazy val clients = Seq(scalaExercisesClient)
 lazy val scalaV = "2.11.7"
 
-lazy val scalaExercisesServer = (project in file("scala-exercises-server")).settings(
+lazy val commonSettings = Seq(
   scalaVersion := scalaV,
-  routesImport += "config.Routes._",
-  scalaJSProjects := clients,
-  pipelineStages := Seq(scalaJSProd, gzip),
-  resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
-  libraryDependencies ++= Seq(
-    filters,
-    jdbc,
-    evolutions,
-    cache,
-    ws,
-    specs2 % Test,
-    "com.typesafe.slick" %% "slick" % "3.0.0-RC1",
-    "org.slf4j" % "slf4j-nop" % "1.6.4",
-    "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",
-    "com.vmunier" %% "play-scalajs-scripts" % "0.2.1",
-    "com.lihaoyi" %% "upickle" % "0.2.8",
-    "org.webjars" %% "webjars-play" % "2.3.0",
-    "org.webjars" % "bootstrap-sass" % "3.2.0",
-    "org.webjars" % "jquery" % "2.1.1",
-    "org.webjars" % "font-awesome" % "4.1.0",
-    "com.tristanhunt" %% "knockoff" % "0.8.3",
-    "org.scala-lang" % "scala-compiler" % scalaV,
-    "org.clapper" %% "classutil" % "1.0.5",
-    "com.toddfast.typeconverter" % "typeconverter" % "1.0",
-    "org.typelevel" %% "scalaz-specs2" % "0.3.0" % "test"
-  )
+  wartremoverWarnings in (Compile, compile) ++= Warts.unsafe)
+
+lazy val scalaExercisesServer = (project in file("scala-exercises-server"))
+  .settings(commonSettings: _*)
+  .settings(
+    routesImport += "config.Routes._",
+    scalaJSProjects := clients,
+    pipelineStages := Seq(scalaJSProd, gzip),
+    resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
+    libraryDependencies ++= Seq(
+      filters,
+      jdbc,
+      evolutions,
+      cache,
+      ws,
+      specs2 % Test,
+      "com.typesafe.slick" %% "slick" % "3.0.0-RC1",
+      "org.slf4j" % "slf4j-nop" % "1.6.4",
+      "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",
+      "com.vmunier" %% "play-scalajs-scripts" % "0.2.1",
+      "com.lihaoyi" %% "upickle" % "0.2.8",
+      "org.webjars" %% "webjars-play" % "2.3.0",
+      "org.webjars" % "bootstrap-sass" % "3.2.0",
+      "org.webjars" % "jquery" % "2.1.1",
+      "org.webjars" % "font-awesome" % "4.1.0",
+      "com.tristanhunt" %% "knockoff" % "0.8.3",
+      "org.scala-lang" % "scala-compiler" % scalaV,
+      "org.clapper" %% "classutil" % "1.0.5",
+      "com.toddfast.typeconverter" % "typeconverter" % "1.0",
+      "org.typelevel" %% "scalaz-specs2" % "0.3.0" % "test"
+    )
 
 ).enablePlugins(PlayScala).
     aggregate(clients.map(projectToRef): _*).
     dependsOn(scalaExercisesSharedJvm, scalaExercisesContent)
 
-lazy val scalaExercisesClient = (project in file("scala-exercises-client")).settings(
-  scalaVersion := scalaV,
-  persistLauncher := true,
-  persistLauncher in Test := false,
-  sourceMapsDirectories += scalaExercisesSharedJs.base / "..",
-  jsDependencies += RuntimeDOM,
-  testFrameworks += new TestFramework("utest.runner.Framework"),
-  libraryDependencies ++= Seq(
-    "org.scala-js" %%% "scalajs-dom" % "0.8.1",
-    "com.lihaoyi" %%% "scalatags" % "0.5.2",
-    "com.lihaoyi" %%% "scalarx" % "0.2.8",
-    "be.doeraene" %%% "scalajs-jquery" % "0.8.0",
-    "com.lihaoyi" %%% "utest" % "0.3.1" % "test",
-    "com.lihaoyi" %%% "upickle" % "0.2.8"
-  )
-).enablePlugins(ScalaJSPlugin, ScalaJSPlay).
-    dependsOn(scalaExercisesSharedJs)
+lazy val scalaExercisesClient = (project in file("scala-exercises-client"))
+  .settings(commonSettings: _*)
+  .settings(
+    persistLauncher := true,
+    persistLauncher in Test := false,
+    sourceMapsDirectories += scalaExercisesSharedJs.base / "..",
+    jsDependencies += RuntimeDOM,
+    testFrameworks += new TestFramework("utest.runner.Framework"),
+    libraryDependencies ++= Seq(
+      "org.scala-js" %%% "scalajs-dom" % "0.8.1",
+      "com.lihaoyi" %%% "scalatags" % "0.5.2",
+      "com.lihaoyi" %%% "scalarx" % "0.2.8",
+      "be.doeraene" %%% "scalajs-jquery" % "0.8.0",
+      "com.lihaoyi" %%% "utest" % "0.3.1" % "test",
+      "com.lihaoyi" %%% "upickle" % "0.2.8"
+    )
+  ).enablePlugins(ScalaJSPlugin, ScalaJSPlay).
+      dependsOn(scalaExercisesSharedJs)
 
-lazy val scalaExercisesShared = (crossProject.crossType(CrossType.Pure) in file("scala-exercises-shared")).
-    settings(
-      scalaVersion := scalaV,
+lazy val scalaExercisesShared = (crossProject.crossType(CrossType.Pure) in file("scala-exercises-shared"))
+  .settings(commonSettings: _*)
+  .settings(
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "2.2.4",
         "org.scalaz" %% "scalaz-core" % "7.1.4"
@@ -70,9 +75,9 @@ lazy val scalaExercisesShared = (crossProject.crossType(CrossType.Pure) in file(
 lazy val scalaExercisesSharedJvm = scalaExercisesShared.jvm
 lazy val scalaExercisesSharedJs = scalaExercisesShared.js
 
-lazy val scalaExercisesContent = (project in file("scala-exercises-content")).
-    settings(
-      scalaVersion := scalaV,
+lazy val scalaExercisesContent = (project in file("scala-exercises-content"))
+  .settings(commonSettings: _*)
+  .settings(
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "2.2.4",
         "org.scalaz" %% "scalaz-core" % "7.1.4"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,3 +19,5 @@ addSbtPlugin("com.vmunier" % "sbt-play-scalajs" % "0.2.6")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 
 addSbtPlugin("default" % "sbt-sass" % "0.1.9")
+
+addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")


### PR DESCRIPTION
Issue #59 

This PR:

* Includes the `wartremover` plugin
* Adds a new `commonSetting` declaration to reuse it in all projects definitions

Now, the *broken rules* are marked as warnings. I'm wondering if we can include some rules as erros. My candidates are:
* [ListOps](https://github.com/puffnfresh/wartremover/blob/1e779589235f7ee3447f0e8c8996b9fcd259d267/README.md#listops)
* [Null](https://github.com/puffnfresh/wartremover/blob/1e779589235f7ee3447f0e8c8996b9fcd259d267/README.md#null)
* [Return](https://github.com/puffnfresh/wartremover/blob/1e779589235f7ee3447f0e8c8996b9fcd259d267/README.md#return)

Please @raulraja could you review? Thanks

@rafaparadela thoughts?