### PR TITLE
Use local H2 DB when running application server

### DIFF
--- a/scala-exercises-server/conf/application.conf
+++ b/scala-exercises-server/conf/application.conf
@@ -33,16 +33,11 @@ application.langs="en"
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
-//db.default.driver=org.h2.Driver
-//db.default.url="jdbc:h2:mem:play"
-//db.default.username=sa
-//db.default.password=""
 
-db.default.driver=org.postgresql.Driver
-db.default.url="jdbc:postgresql://localhost:5432/scalaexercises"
-db.default.username=scalaexercises_user
-db.default.password="scalaexercises_pass"
-
+db.default.driver=org.h2.Driver
+db.default.url="jdbc:h2:file:~/.scala-exercises/db"
+db.default.username=sa
+db.default.password=""
 
 # Slick
 # ~~~~~

--- a/scala-exercises-server/conf/application.conf
+++ b/scala-exercises-server/conf/application.conf
@@ -35,7 +35,7 @@ application.langs="en"
 #
 
 db.default.driver=org.h2.Driver
-db.default.url="jdbc:h2:file:~/.scala-exercises/db"
+db.default.url="jdbc:h2:file:~/.scala-exercises/db;DATABASE_TO_UPPER=false"
 db.default.username=sa
 db.default.password=""
 


### PR DESCRIPTION
This updates the project to use a local H2 DB (persisted to `~/.scala-exercises/db`) when `sbt run` is performed. Previously, Postgres was required to be running locally.