### PR TITLE
Fixing evolution & evaluate ajax call

### DIFF
--- a/site/client/src/main/scala/config/Routes.scala
+++ b/site/client/src/main/scala/config/Routes.scala
@@ -3,7 +3,7 @@ package config
 import scala.scalajs.js
 
 object Routes {
-  private val controllers = js.Dynamic.global.jsRoutes.controllers
+  private val controllers = js.Dynamic.global.jsRoutes.com.fortysevendeg.exercises.controllers
 
   object Exercises {
     def libraries: String =

--- a/site/server/app/com/fortysevendeg/exercises/models/UserQueries.scala
+++ b/site/server/app/com/fortysevendeg/exercises/models/UserQueries.scala
@@ -8,34 +8,34 @@ import com.fortysevendeg.exercises.models.UserCreation
 object Queries {
   val all = sql"""
 SELECT id, login, name, githubId, pictureUrl, githubUrl, email
-FROM User
+FROM users
 """.query[User]
 
   def byLogin(login: String) =
     sql"""
 SELECT id, login, name, githubId, pictureUrl, githubUrl, email
-FROM User
+FROM users
 WHERE login = $login
 """.query[User]
 
   def byId(id: Long) =
     sql"""
 SELECT id, login, name, githubId, pictureUrl, githubUrl, email
-FROM User
+FROM users
 WHERE id = $id
 """.query[User]
 
   def insert(user: UserCreation.Request) = {
     val UserCreation.Request(login, name, githubId, pictureUrl, githubUrl, email) = user
     sql"""
-INSERT INTO User (login, name, githubId, pictureUrl, githubUrl, email)
+INSERT INTO users (login, name, githubId, pictureUrl, githubUrl, email)
 VALUES ($login, $name, $githubId, $pictureUrl, $githubUrl, $email)
 """.update
   }
 
   def deleteById(id: Long) =
     sql"""
-DELETE FROM User
+DELETE FROM users
       WHERE id = $id
     """.update
 
@@ -46,13 +46,13 @@ DELETE FROM User
 
   def deleteAll =
     sql"""
-DELETE FROM User
+DELETE FROM users
     """.update
 
   def update(user: User) = {
     val User(id, _, name, githubId, pictureUrl, githubUrl, email) = user
     sql"""
-UPDATE User
+UPDATE users
 SET    name = $name,
        githubId = $githubId,
        pictureUrl = $pictureUrl,

--- a/site/server/conf/application.conf
+++ b/site/server/conf/application.conf
@@ -36,10 +36,11 @@ play.application.loader=com.fortysevendeg.exercises.ExercisesApplicationLoader
 # By convention, the default datasource is named `default`
 #
 
-db.default.driver=org.h2.Driver
-db.default.url="jdbc:h2:file:~/.scala-exercises/db;DATABASE_TO_UPPER=false"
-db.default.username=sa
-db.default.password=""
+db.default.driver=org.postgresql.Driver
+db.default.url="jdbc:postgresql://localhost:5432/scalaexercises"
+db.default.url=${?DATABASE_URL}
+db.default.username=scalaexercises_user
+db.default.password="scalaexercises_pass"
 
 # Evolutions
 # ~~~~~

--- a/site/server/conf/evolutions/default/1.sql
+++ b/site/server/conf/evolutions/default/1.sql
@@ -1,15 +1,15 @@
 # --- !Ups
 
-CREATE TABLE User (
-    id bigint primary key auto_increment,
-    login varchar(255) unique not null,
-    name varchar(255) not null,
-    githubId varchar(255) not null,
-    pictureUrl varchar(255) not null,
-    githubUrl varchar(255) not null,
-    email varchar(255) not null
+CREATE TABLE users (
+    id bigserial primary key,
+    login text UNIQUE NOT NULL,
+    name text NOT NULL,
+    githubId text NOT NULL,
+    pictureUrl text NOT NULL,
+    githubUrl text NOT NULL,
+    email text NOT NULL
 );
 
 # --- !Downs
 
-DROP TABLE User;
+DROP TABLE users;


### PR DESCRIPTION
This PR resolves the issues:
- Evolution sql written as mysql style, instead of postgreslq.
- Unable to find the route to call the evaluation endpoint.

@andyscott  you should be able to have your stuff working once this PR is merged into version-2.
@juanpedromoreno  you should be able to run the ajax call to `evaluate` exercises in the client.

Note: 
- Remember to setup a postgres database called `scalaexercises`



@raulraja @dialelo Could you take a look please? thank you.