### PR TITLE
Add env. vars for GitHub integration

### DIFF
--- a/site/server/conf/application.conf
+++ b/site/server/conf/application.conf
@@ -67,5 +67,9 @@ logger.application=DEBUG
 
 # env vars for github auth
 github.client.id="e8e39175648c9db8c280"
+github.client.id=${?GITHUB_CLIENT_ID}
+
 github.client.secret="7c179a89feb1c557892eec2513451378b39e762f"
+github.client.secret=${?GITHUB_CLIENT_SECRET}
+
 github.redirect.url="https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s"


### PR DESCRIPTION
This PR solves #165 , I have:
- created a new developer application under 47deg account.
- set two environment variables for Heroku app `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`.
- added two overriding params in `application.conf` to get these variables in prod.

We need this PR in order to have the oAuth flow enabled in production environment.

@dialelo @raulraja @FPerezP @juanpedromoreno Could you review please? Thank you.