### PR TITLE
Various compiler updates and fixes, round 2

### DIFF
--- a/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
+++ b/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
@@ -91,9 +91,10 @@ object DocParser {
     else start
 
   // Our own creation
-  private def trimTrailingWhitespace(str: String, start: Int, end: Int): Int =
-    if (end >= start && isWhitespace(str charAt (end - 1))) trimTrailingWhitespace(str, start, end - 1)
+  private def trimTrailingWhitespace(str: String, start: Int, end: Int): Int = {
+    if (end > start && isWhitespace(str charAt (end - 1))) trimTrailingWhitespace(str, start, end - 1)
     else end
+  }
 
   // Verbatim copy of DocStrings.skipLineLead
   private def skipLineLead(str: String, start: Int): Int =

--- a/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
+++ b/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
@@ -114,7 +114,7 @@ object DocParser {
 
   // ~ END
 
-  private def cleanLines(lines: List[String]): List[String] = {
+  private[compiler] def cleanLines(lines: List[String]): List[String] = {
     lines.map { line ⇒
       val ll = skipLineLead(line, -1)
       val le0 = skipToEol(line, ll)
@@ -123,9 +123,13 @@ object DocParser {
     }
       .dropWhile(_.isEmpty)
       .reverse
+      .dropWhile(_.isEmpty)
       .dropWhile(_ == "/")
       .dropWhile(_.isEmpty)
       .reverse
   }
+
+  private[compiler] def cleanLines(blob: String): List[String] =
+    cleanLines(blob.lines.toList)
 
 }

--- a/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/DocParserSpec.scala
+++ b/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/DocParserSpec.scala
@@ -1,0 +1,17 @@
+package com.fortysevendeg.exercises
+package compiler
+
+import org.scalatest._
+
+class DocParserSpec extends FunSpec with Matchers {
+  describe("Exercise comments") {
+    it("can be parsed even when having trailing whitespace") {
+      val comment = """
+      /** The next line has a trailing whitespace
+        * 
+        */
+      """
+      assert(DocParser.parseLibraryDocComment(comment).isRight)
+    }
+  }
+}

--- a/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/DocParserSpec.scala
+++ b/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/DocParserSpec.scala
@@ -8,7 +8,7 @@ class DocParserSpec extends FunSpec with Matchers {
     it("can be parsed even when having trailing whitespace") {
       val comment = """
       /** The next line has a trailing whitespace
-        * 
+        *
         */
       """
       assert(DocParser.parseLibraryDocComment(comment).isRight)

--- a/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/DocParserSpec.scala
+++ b/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/DocParserSpec.scala
@@ -1,17 +1,179 @@
 package com.fortysevendeg.exercises
 package compiler
 
+import cats.data.Xor
+
 import org.scalatest._
 
 class DocParserSpec extends FunSpec with Matchers {
-  describe("Exercise comments") {
-    it("can be parsed even when having trailing whitespace") {
+  import DocParser._
+
+  val content1 = "This is comment content 1"
+  val content2 = "This is comment content 2"
+  val content3 = "Hello World!!!!!!!"
+
+  def joinWithSpaces(content: String*) =
+    content.mkString(" ")
+
+  describe("library comment parsing") {
+
+    it("fails when no description is provided") {
       val comment = """
-      /** The next line has a trailing whitespace
+      /** Library Name
         *
         */
       """
-      assert(DocParser.parseLibraryDocComment(comment).isRight)
+      assert(DocParser.parseLibraryDocComment(comment).isLeft)
+    }
+
+    it("captures the first line as name and the rest as description") {
+      val comment = s"""
+      /** $content1
+        * $content2
+        * $content3
+        */
+      """
+      val res = DocParser.parseLibraryDocComment(comment)
+      res should equal(Xor.right(ParsedLibraryComment(
+        name = content1,
+        description = joinWithSpaces(content2, content3)
+      )))
+    }
+
+  }
+
+  describe("line cleaning") {
+
+    it("strips comment container and leading/trailing whitespace") {
+
+      {
+        info("leading line before comment")
+        val comment =
+          s"""|
+              |/** $content1 */""".stripMargin
+
+        val res = DocParser.cleanLines(comment)
+        res should equal(content1 :: Nil)
+      }
+
+      {
+        info("leading line before comment")
+        info("and leading line in comment")
+        val comment =
+          s"""|
+              |/**
+              |  * $content1 */""".stripMargin
+
+        val res = DocParser.cleanLines(comment)
+        res should equal(content1 :: Nil)
+      }
+
+      {
+        info("trailing line after comment")
+        val comment =
+          s"""|/** $content1 */
+              |""".stripMargin
+
+        val res = DocParser.cleanLines(comment)
+        res should equal(content1 :: Nil)
+      }
+
+      {
+        info("trailing line in comment")
+        info("and trailing line after comment")
+
+        val comment =
+          s"""|/** $content1
+              |  */
+              |""".stripMargin
+
+        val res = DocParser.cleanLines(comment)
+        res should equal(content1 :: Nil)
+      }
+
+      {
+        info("leading line before comment")
+        info("and trailing lines after comment")
+        info("with multiple comment lines")
+
+        val comment =
+          s"""|
+              |/** $content1
+              |  * $content2
+              |  */
+              |
+              |
+              |""".stripMargin
+
+        val res = DocParser.cleanLines(comment)
+        res should equal(content1 :: content2 :: Nil)
+      }
+
+      {
+        info("leading line before comment")
+        info("and trailing lines after comment")
+        info("with multiple comment lines")
+        info("and empty lines between the comments")
+
+        val comment =
+          s"""|
+              |/** $content1
+              |  *
+              |  *
+              |  * $content2 */
+              |
+              |
+              |""".stripMargin
+
+        val res = DocParser.cleanLines(comment)
+        res should equal(content1 :: "" :: "" :: content2 :: Nil)
+      }
+
+      {
+        info("leading line before comment")
+        info("and trailing lines after comment")
+        info("with multiple comment lines")
+        info("and empty lines between the comments")
+        info("and trailing line in comment")
+
+        val comment =
+          s"""|
+              |/** $content1
+              |  *
+              |  *
+              |  * $content2
+              |  */
+              |
+              |
+              |""".stripMargin
+
+        val res = DocParser.cleanLines(comment)
+        res should equal(content1 :: "" :: "" :: content2 :: Nil)
+      }
+
+      {
+        info("leading lines before comment")
+        info("and trailing lines after comment")
+        info("with multiple comment lines")
+        info("and empty lines between the comments")
+        info("and leading lines in the comment")
+        info("and trailing line in comment")
+
+        val comment =
+          s"""|
+              |/** $content1
+              |  *
+              |  *
+              |  * $content2
+              |  * $content3
+              |  */
+              |
+              |
+              |""".stripMargin
+
+        val res = DocParser.cleanLines(comment)
+        res should equal(content1 :: "" :: "" :: content2 :: content3 :: Nil)
+      }
     }
   }
 }


### PR DESCRIPTION
changes in c0de1e8
- @dialelo's regression for #182 

changes in 65f767e
- fixes #182 
- unblocks #167

changes in  8e58f0b
- improved whitespace trimming logic
- improved parsing tests as a whole