### PR TITLE
Use proper library for a given section when loading library index page

### DIFF
--- a/site/server/app/com/fortysevendeg/exercises/controllers/ApplicationController.scala
+++ b/site/server/app/com/fortysevendeg/exercises/controllers/ApplicationController.scala
@@ -61,7 +61,7 @@ class ApplicationController(
       val ops = for {
         libraries ← exerciseOps.getLibraries
         section ← exerciseOps.getSection(libraryName, sectionName)
-      } yield (libraries.headOption, section)
+      } yield (libraries.find(_.name == libraryName), section)
       ops.runTask match {
         case Xor.Right((Some(l), Some(s))) ⇒ Ok(views.html.templates.library.index(l, s))
         case Xor.Right((Some(l), None))    ⇒ Redirect(l.sectionNames.head)


### PR DESCRIPTION
We were always using the first library when we needed to actually search for the correct one. This is a quick little fix for the bug.