### PR TITLE
Support evaluating exercise

### DIFF
--- a/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/Compiler.scala
+++ b/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/Compiler.scala
@@ -41,9 +41,10 @@ case class Compiler() {
     )
 
     case class ExerciseInfo(
-      symbol:  MethodSymbol,
-      comment: DocParser.ParsedExerciseComment,
-      code:    String
+      symbol:          MethodSymbol,
+      comment:         DocParser.ParsedExerciseComment,
+      code:            String,
+      qualifiedMethod: String
     )
 
     def enhanceDocError(symbol: Symbol)(error: String) =
@@ -92,7 +93,8 @@ case class Compiler() {
     } yield ExerciseInfo(
       symbol = symbol,
       comment = comment,
-      code = code
+      code = code,
+      qualifiedMethod = internal.symbolToPath(symbol).mkString(".")
     )
 
     // keeping this, as it's very useful for debugging
@@ -128,7 +130,8 @@ case class Compiler() {
                 treeGen.makeExercise(
                   name = exerciseInfo.comment.name,
                   description = exerciseInfo.comment.description,
-                  code = Some(exerciseInfo.code),
+                  code = Some(exerciseInfo.code), // TODO: remove wrapper
+                  qualifiedMethod = Some(exerciseInfo.qualifiedMethod), // TODO: remove wrapper
                   explanation = exerciseInfo.comment.explanation
                 )
               }.unzip

--- a/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/TreeGen.scala
+++ b/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/TreeGen.scala
@@ -12,22 +12,25 @@ case class TreeGen[U <: Universe](
 ) {
   import u._
 
-  def makeExercise(name: Option[String], description: Option[String], code: Option[String], explanation: Option[String]) = {
+  def makeExercise(
+    name: Option[String], description: Option[String],
+    code: Option[String], qualifiedMethod: Option[String],
+    explanation: Option[String]
+  ) = {
     val term = makeTermName("Exercise", name)
     term → q"""
         object $term extends Exercise {
-          override val name         = $name
-          override val description  = $description
-          override val code         = $code
-          override val explanation  = $explanation
-
-          override type Input       = Unit
-          override val eval         = None
+          override val name             = $name
+          override val description      = $description
+          override val code             = $code
+          override val qualifiedMethod  = $qualifiedMethod
+          override val explanation      = $explanation
         }"""
   }
 
   def makeSection(
-    name: String, description: Option[String], exerciseTerms: List[TermName]
+    name: String, description: Option[String],
+    exerciseTerms: List[TermName]
   ) = {
     val term = makeTermName("Section", name)
     term → q"""
@@ -53,7 +56,8 @@ case class TreeGen[U <: Universe](
   }
 
   def makePackage(
-    packageName: String, trees: List[Tree]
+    packageName: String,
+    trees:       List[Tree]
   ) = q"""
         package ${makeRefTree(packageName)} {
           import com.fortysevendeg.exercises.Exercise

--- a/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/TreeGenSpec.scala
+++ b/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/TreeGenSpec.scala
@@ -21,12 +21,14 @@ class TreeGenSpec extends FunSpec with Matchers {
           name = Some("Example1"),
           description = None,
           code = None,
+          qualifiedMethod = None,
           explanation = None
         ),
         treeGen.makeExercise(
           name = Some("Example2"),
           description = None,
           code = None,
+          qualifiedMethod = None,
           explanation = None
         )
       )

--- a/core/runtime/src/main/scala/com/fortysevendeg/exercises/model.scala
+++ b/core/runtime/src/main/scala/com/fortysevendeg/exercises/model.scala
@@ -22,17 +22,11 @@ trait Section {
 /** Exercises within a section.
   */
 trait Exercise {
-  type Input
-
   def name: Option[String]
   def description: Option[String]
   def code: Option[String]
-  def eval: Option[Input ⇒ Unit]
+  def qualifiedMethod: Option[String]
   def explanation: Option[String]
-}
-
-object Exercise {
-  type Aux[A] = Exercise { type Input = A }
 }
 
 // default case class implementations
@@ -49,12 +43,10 @@ case class DefaultSection(
   exercises:   List[Exercise] = Nil
 ) extends Section
 
-case class DefaultExercise[A](
-    name:        Option[String]   = None,
-    description: Option[String]   = None,
-    code:        Option[String]   = None,
-    eval:        Option[A ⇒ Unit] = None,
-    explanation: Option[String]   = None
-) extends Exercise {
-  type Input = A
-}
+case class DefaultExercise(
+  name:            Option[String] = None,
+  description:     Option[String] = None,
+  code:            Option[String] = None,
+  qualifiedMethod: Option[String] = None,
+  explanation:     Option[String] = None
+) extends Exercise


### PR DESCRIPTION
This should ultimately bring support for evaluating simple exercises.

I've updated the compiler to output the fully qualified method name for evaluating the exercise. An example path might be `stdlib.ClassExercises.classExercise1` where `stdlib` is a package, `ClassExercises` is an object implementing the `exercise.Section` trait, and `classExercise1` is a method that can be invoked via reflection.

I am blocked on implementing the rest of this as I am unable to log in on a locally running instance and the eval route requires authentication. How should I proceed?