### PR TITLE
Allow user emails to be null

### DIFF
--- a/site/server/app/com/fortysevendeg/exercises/models/UserModel.scala
+++ b/site/server/app/com/fortysevendeg/exercises/models/UserModel.scala
@@ -24,7 +24,7 @@ object UserCreation {
       githubId:   String,
       pictureUrl: String,
       githubUrl:  String,
-      email:      String
+      email:      Option[String]
   ) {
 
     def asUser(id: Long): User =

--- a/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -14,8 +14,6 @@ import com.fortysevendeg.exercises.services.interpreters.ProdInterpreters
 
 import com.fortysevendeg.exercises.models._
 import com.fortysevendeg.exercises.services.free.UserOps
-import com.fortysevendeg.exercises.app._
-import com.fortysevendeg.exercises.services._
 
 import doobie.imports._
 import cats.data.Xor
@@ -84,13 +82,12 @@ class OAuth2Controller(
       ws.url("https://api.github.com/user").
         withHeaders(HeaderNames.AUTHORIZATION → s"token $authToken").
         get().map { response ⇒
-
           val login = (response.json \ "login").as[String]
           val name = (response.json \ "name").as[String]
           val githubId = (response.json \ "id").as[Long]
           val avatarUrl = (response.json \ "avatar_url").as[String]
           val htmlUrl = (response.json \ "html_url").as[String]
-          val email = (response.json \ "email").as[String]
+          val email = (response.json \ "email").asOpt[String]
 
           UserDoobieStore.getOrCreate(
             UserCreation.Request(

--- a/site/server/conf/evolutions/default/1.sql
+++ b/site/server/conf/evolutions/default/1.sql
@@ -7,7 +7,7 @@ CREATE TABLE "users" (
     githubId varchar(255) UNIQUE NOT NULL,
     pictureUrl varchar(255) NOT NULL,
     githubUrl varchar(255) NOT NULL,
-    email varchar(255) NOT NULL
+    email varchar(255)
 );
 
 # --- !Downs

--- a/site/server/test/ArbitraryInstances.scala
+++ b/site/server/test/ArbitraryInstances.scala
@@ -37,7 +37,7 @@ trait ArbitraryInstances extends Assertions {
       githubId = githubId.toString,
       pictureUrl = pictureUrl,
       githubUrl = githubUrl,
-      email = email
+      email = Some(email)
     ))
 
   def persistentUserArbitrary(implicit transactor: Transactor[Task]): Arbitrary[User] = {

--- a/site/server/test/UserQueriesSpec.scala
+++ b/site/server/test/UserQueriesSpec.scala
@@ -23,7 +23,7 @@ class UserQueriesSpec extends Specification with AnalysisSpec with DatabaseInsta
       githubId = "47deg",
       pictureUrl = "http://placekitten.com/50/50",
       githubUrl = "http://github.com/47deg",
-      email = "hello@47deg.com"
+      email = Some("hello@47deg.com")
     )
   ))
   check(Queries.deleteById(47))
@@ -35,7 +35,7 @@ class UserQueriesSpec extends Specification with AnalysisSpec with DatabaseInsta
       githubId = "47deg",
       pictureUrl = "http://placekitten.com/50/50",
       githubUrl = "http://github.com/47deg",
-      email = "hello@47deg.com"
+      email = Some("hello@47deg.com")
     )
   ))
 }

--- a/site/server/test/UserStoreSpec.scala
+++ b/site/server/test/UserStoreSpec.scala
@@ -97,7 +97,7 @@ class UserStoreSpec
 
       val storedUser = UserDoobieStore.getByLogin(newUser.login).transact(transactor).run
       storedUser.fold(false)(u ⇒ {
-        val modifiedUser = u.copy(email = "alice+spam@example.com")
+        val modifiedUser = u.copy(email = Some("alice+spam@example.com"))
         UserDoobieStore.update(modifiedUser).quick.run
 
         UserDoobieStore.getByLogin(u.login).transact(transactor).run == Some(modifiedUser)

--- a/site/shared/src/main/scala/shared/User.scala
+++ b/site/shared/src/main/scala/shared/User.scala
@@ -9,7 +9,7 @@ case class User(
   githubId:   String,
   pictureUrl: String,
   githubUrl:  String,
-  email:      String
+  email:      Option[String]
 )
 
 case class UserProgress(


### PR DESCRIPTION
Users may set their GitHub email to private, which results in a `null` in the JSON payload received during the Oauth cycle. (See https://developer.github.com/v3/users/#get-a-single-user)

Previously an exception was thrown because the unmarshaller didn't expect the null. This fix changes the email field to an `Option[String]`, after demarshalling.

It also lets me log in to the app, because I'm one of said users!