### PR TITLE
Fix authentication issues

### DIFF
--- a/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -80,7 +80,7 @@ class OAuth2Controller(
   }
 
   def success() = Action.async { request ⇒
-    request.session.get("oauth-token").fold(Future.successful(Unauthorized("No way Jose"))) { authToken ⇒
+    request.session.get("oauth-token").fold(Future.successful(Unauthorized("Unauthorized"))) { authToken ⇒
       ws.url("https://api.github.com/user").
         withHeaders(HeaderNames.AUTHORIZATION → s"token $authToken").
         get().map { response ⇒
@@ -102,7 +102,7 @@ class OAuth2Controller(
               email
             )
           ).transact(T).run match {
-              case Xor.Right(_) ⇒ Redirect("/").withSession("oauth-token" → authToken, "user" → login)
+              case Xor.Right(_) ⇒ Redirect(request.headers.get("referer").getOrElse("/")).withSession("oauth-token" → authToken, "user" → login)
               case Xor.Left(_)  ⇒ InternalServerError("Failed to save user information")
             }
 

--- a/site/server/app/views/templates/base/userInfo.scala.html
+++ b/site/server/app/views/templates/base/userInfo.scala.html
@@ -8,7 +8,7 @@
   <ul class="dropdown-menu">
     <li><a href="@user.githubUrl">View on GitHub</a>
     </li>
-    <li><a href="logout">Logout</a>
+    <li><a href="/logout">Logout</a>
     </li>
   </ul>
 </li>

--- a/site/server/app/views/templates/home/index.scala.html
+++ b/site/server/app/views/templates/home/index.scala.html
@@ -43,7 +43,7 @@
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav navbar-right">
             @user match {
-              case Some(u) => { @templates.home.userInfo(u) }
+              case Some(u) => { @templates.base.userInfo(u) }
               case None => { <li><a href="@redirectUrl"><i class="fa fa-github"></i>Login with GitHub</a></li> }
             }
           </ul>

--- a/site/server/app/views/templates/library/index.scala.html
+++ b/site/server/app/views/templates/library/index.scala.html
@@ -1,4 +1,4 @@
-@(library: shared.Library, section: shared.Section)(implicit request: RequestHeader)
+@(library: shared.Library, section: shared.Section, user: Option[shared.User] = None, redirectUrl: Option[String] = Some("#"))(implicit request: RequestHeader)
 
 @import com.fortysevendeg.exercises.utils.StringUtils._
 
@@ -131,24 +131,16 @@
             <svg viewBox="0 0 34 22" width="34" height="22">
               <use xlink:href="@routes.Assets.at("images/sprite-images.svg#brand")"/>
             </svg>
-            <span>Scala Exercises / <span class="section-name">@section.name</span> </span>
+            <span>Scala Exercises / <span class="section-name">@library.name</span> </span>
           </a>
         </div>
 
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav navbar-right">
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <img src="http://avatars3.githubusercontent.com/u/315070" alt=""> Rafa Paradela
-                <span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="#">View on GitHub</a>
-                </li>
-                <li><a href="#">Logout</a>
-                </li>
-              </ul>
-            </li>
+          @user match {
+            case Some(u) => { @templates.base.userInfo(u) }
+            case None => { <li><a href="@redirectUrl"><i class="fa fa-github"></i>Login with GitHub</a></li> }
+          }
           </ul>
         </div>
           <!--.nav-collapse -->


### PR DESCRIPTION
This PR resolves issues exposed in #229:

- [x] Sometime, although the button to login seems available to start the process, it doesn't work because the user is already logged. For that reason, visiting the /logout endpoint usually solves the inconsistent status. However, the button should show the real auth status accordingly.
- [x] On the other hand, in Exercises screen, the auth button should show the actual status as well, instead of the mocked partial template with my name/face.
- [ ] Due to exercises shouldn't be evaluated for unlogged users, we should check this condition previous to the evaluation call. And show a modal with the invitation for signing up.