### PR TITLE
Set the exercise as Unsolved when it's changed after a succeeded evaluation

### DIFF
--- a/site/client/src/main/scala/Model.scala
+++ b/site/client/src/main/scala/Model.scala
@@ -43,7 +43,7 @@ object Exercises {
     })
 
   def updateByMethod(s: State, method: String, args: Seq[String]): State =
-    applyByMethod(s, method, _.copy(arguments = args))
+    applyByMethod(s, method, _.copy(arguments = args, state = Unsolved))
 
   def evaluate(s: State, method: String): State = findByMethod(s, method) match {
     case Some(exercise) if exercise.canBeCompiled ⇒ applyByMethod(s, method, _.copy(state = Evaluating))


### PR DESCRIPTION
As a result of the issue #240, I noticed that once an exercises is successfully evaluated, is not possible running the evaluation again.
I guess the right behaviour is allow that exercises can be evaluated once and again. So this PR set the exercise as unsolved when is changed (although it had been set as solved previously), allowing to run the evaluation again.

@raulraja @dialelo Does this make sense for you?