### PR TITLE
Show section progress

### DIFF
--- a/site/server/app/assets/stylesheets/layout/_sidebar.scss
+++ b/site/server/app/assets/stylesheets/layout/_sidebar.scss
@@ -44,7 +44,7 @@
 								z-index: 30;
             }
             .bullet-active {
-                background: $brand-primary;
+                background: $gray;
             }
             a {
 								display: inline-block;

--- a/site/server/app/views/templates/library/index.scala.html
+++ b/site/server/app/views/templates/library/index.scala.html
@@ -1,4 +1,4 @@
-@(library: shared.Library, section: shared.Section, user: Option[shared.User] = None, redirectUrl: Option[String] = Some("#"))(implicit request: RequestHeader)
+@(library: shared.Library, section: shared.Section, progress: shared.LibrarySections, user: Option[shared.User] = None, redirectUrl: Option[String] = Some("#"))(implicit request: RequestHeader)
 
 @import com.fortysevendeg.exercises.utils.StringUtils._
 
@@ -167,14 +167,19 @@
     <div id="wrapper">
 
       <section id="sidebar">
-        @templates.widgets.progress(1, library.sections.size, library.color)
+        @templates.widgets.progress(progress.completedSections, progress.totalSections, library.color)
         <ul>
           <li>
             <h3>Categories</h3>
           </li>
 
           @for(sectionName <- library.sectionNames) {
-            @templates.library.sectionRow(sectionName, library.color, sectionName == section.name)
+	    @templates.library.sectionRow(
+	      sectionName = sectionName,
+	      color = library.color,
+	      highlight = sectionName == section.name,
+	      completed = progress.sections.find(_.sectionName == sectionName).fold(false)(_.succeeded)
+	    )
           }
 
         </ul>

--- a/site/server/app/views/templates/library/sectionRow.scala.html
+++ b/site/server/app/views/templates/library/sectionRow.scala.html
@@ -1,8 +1,8 @@
-@(sectionName: String, color: String, highlight: Boolean)(implicit request: RequestHeader)
+@(sectionName: String, color: String, highlight: Boolean, completed: Boolean)(implicit request: RequestHeader)
 @import com.fortysevendeg.exercises.utils.StringUtils._
 
 <li class="actives">
-  <span class="bullet-active" style="background-color: @color;"></span>
+  <span class="bullet-active" @if(completed) { style="background-color: @color;" }></span>
   <a href="@sectionName" @if(highlight){ style="color: @color; font-weight: bold;" } >
     @sectionName.humanizeCamelCase
   </a>

--- a/site/shared/src/main/scala/shared/User.scala
+++ b/site/shared/src/main/scala/shared/User.scala
@@ -45,6 +45,9 @@ case class LibrarySectionArgs(
 case class SectionInfoItem(sectionName: String, succeeded: Boolean)
 
 case class LibrarySections(
-  libraryName: String,
-  sections:    List[SectionInfoItem]
-)
+    libraryName: String,
+    sections:    List[SectionInfoItem]
+) {
+  def totalSections: Int = sections.size
+  def completedSections: Int = sections.filter(_.succeeded).size
+}


### PR DESCRIPTION
Involves two things:
- [x] Display the progress bar with the number of sections completed for the current library
- [x] Highlight the bullets of the sections that have been completed with the section's color, otherwise draw them with a gray color.

An example with a completed section (Identity is finished but I'm looking at Xor):
![progress-section](https://cloud.githubusercontent.com/assets/409039/13221162/38256674-d97a-11e5-8f15-1c6fcea77d9c.png)

Another with no complete sections:
![progress-section-without-answers](https://cloud.githubusercontent.com/assets/409039/13221172/41c91e00-d97a-11e5-9d92-0c589fba78fd.png)
