### PR TITLE
Renamed Libraries and Sections without spaces

### DIFF
--- a/site/content/src/main/exercises/shapeless/HListExercises.scala
+++ b/site/content/src/main/exercises/shapeless/HListExercises.scala
@@ -18,7 +18,7 @@ object addSize extends Poly2 {
     }
 
 
-/** Heterogenous lists
+/** HeterogenousLists
   *
   * shapeless provides a comprehensive Scala `HList` which has many features not shared by other HList implementations.
   *

--- a/site/content/src/main/exercises/shapeless/PolyExercises.scala
+++ b/site/content/src/main/exercises/shapeless/PolyExercises.scala
@@ -4,7 +4,7 @@ import org.scalatest._
 import shapeless._
 import poly.{~>}
 
-/** Polymorphic function values
+/** PolymorphicFunctionValues
   *
   * Ordinary Scala function values are monomorphic. shapeless, however, provides an encoding of polymorphic
   * function values. It supports natural transformations, which are familiar from libraries like Cats or Scalaz,

--- a/site/content/src/main/exercises/stdlib/PatternMatching.scala
+++ b/site/content/src/main/exercises/stdlib/PatternMatching.scala
@@ -2,7 +2,7 @@ package stdlib
 
 import org.scalatest._
 
-/** Pattern Matching
+/** PatternMatching
   *
   * Scala has a built-in general pattern matching mechanism. It allows to match on any sort of data with a first-match policy.
   */

--- a/site/content/src/main/exercises/stdlib/StdLib.scala
+++ b/site/content/src/main/exercises/stdlib/StdLib.scala
@@ -5,7 +5,7 @@
 
 package stdlib
 
-/** std lib
+/** StdLib
   *
   * Exercises for basic scala
   */

--- a/site/server/app/views/templates/library/index.scala.html
+++ b/site/server/app/views/templates/library/index.scala.html
@@ -170,7 +170,7 @@
         @templates.widgets.progress(1, library)
         <ul>
           <li>
-            <h3>Categories</h3>
+            <h3>Sections</h3>
           </li>
 
           @for(sectionName <- library.sectionNames) {
@@ -186,7 +186,7 @@
             <div class="col-lg-12">
 
               <div class="content-header clearfix">
-                <h2 class="pull-left">@section.name</h2>
+                <h2 class="pull-left">@section.name.humanizeCamelCase</h2>
                 <div class="add-exercises pull-right">
                   <button type="button" class="btn btn-default btn-sm">Add exercises</button>
                 </div>


### PR DESCRIPTION
This PR:
- [x] Renames several libraries/sections without spaces
- [x] Applies a conversion to Humanize camel cases string in the front end.

Ticket: #213 

The result:

![](http://rafp.es/1UhYFRM)

@raulraja @dialelo Could you review please? Thank you.