### PR TITLE
Configure top library order for homepage

### DIFF
--- a/site/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
+++ b/site/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
@@ -49,14 +49,13 @@ object ExercisesService extends RuntimeSharedConversions {
   }
 
   def reorderLibraries(topLibNames: List[String], libraries: List[shared.Library]): List[shared.Library] = {
-    val libsByName = libraries.groupBy(_.name)
-    val topLibs = for {
-      name ← topLibNames
-      lib ← libsByName.get(name).getOrElse(Nil)
-    } yield lib
-    val restLibs = libraries.filterNot(topLibs.contains(_))
-
-    topLibs ++ restLibs
+    libraries.sortBy(lib ⇒ {
+      val idx = topLibNames.indexOf(lib.name)
+      if (idx == -1)
+        Integer.MAX_VALUE
+      else
+        idx
+    })
   }
 }
 

--- a/site/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
+++ b/site/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
@@ -48,6 +48,16 @@ object ExercisesService extends RuntimeSharedConversions {
     )
   }
 
+  def reorderLibraries(topLibNames: List[String], libraries: List[shared.Library]): List[shared.Library] = {
+    val libsByName = libraries.groupBy(_.name)
+    val topLibs = for {
+      name ← topLibNames
+      lib ← libsByName.get(name).getOrElse(Nil)
+    } yield lib
+    val restLibs = libraries.filterNot(topLibs.contains(_))
+
+    topLibs ++ restLibs
+  }
 }
 
 sealed trait RuntimeSharedConversions {

--- a/site/server/conf/application.conf
+++ b/site/server/conf/application.conf
@@ -64,8 +64,10 @@ logger.play=INFO
 # Logger provided to your application:
 logger.application=DEBUG
 
+# GitHub
+# ~~~~~~
+# Config for GitHub Auth
 
-# env vars for github auth
 github.client.id="e8e39175648c9db8c280"
 github.client.id=${?GITHUB_CLIENT_ID}
 
@@ -73,3 +75,8 @@ github.client.secret="7c179a89feb1c557892eec2513451378b39e762f"
 github.client.secret=${?GITHUB_CLIENT_SECRET}
 
 github.redirect.url="https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s"
+
+# Exercises
+# ~~~~~~~~~
+
+exercises.top = [ "Cats", "Shapeless", "StdLib" ]

--- a/site/server/conf/application.conf
+++ b/site/server/conf/application.conf
@@ -79,4 +79,4 @@ github.redirect.url="https://github.com/login/oauth/authorize?client_id=%s&redir
 # Exercises
 # ~~~~~~~~~
 
-exercises.top = [ "Cats", "Shapeless", "StdLib" ]
+exercises.top_libraries = [ "Cats", "Shapeless", "StdLib" ]

--- a/site/server/conf/application.conf
+++ b/site/server/conf/application.conf
@@ -79,4 +79,4 @@ github.redirect.url="https://github.com/login/oauth/authorize?client_id=%s&redir
 # Exercises
 # ~~~~~~~~~
 
-exercises.top_libraries = [ "Cats", "Shapeless", "StdLib" ]
+exercises.top_libraries = [ "StdLib", "Cats", "Shapeless" ]

--- a/site/server/test/com/fortysevendeg/exercises/services/ExercisesServiceSpec.scala
+++ b/site/server/test/com/fortysevendeg/exercises/services/ExercisesServiceSpec.scala
@@ -9,6 +9,8 @@ import org.junit.runner._
 import org.specs2.mutable._
 import org.specs2.runner._
 
+import shared._
+
 @RunWith(classOf[JUnitRunner])
 class ExercisesServiceSpec extends Specification {
 
@@ -20,9 +22,47 @@ class ExercisesServiceSpec extends Specification {
   val expectedTestSuccesArgs = List("Chevy", "Camaro", "1978", "120")
   val expectedTestFailedArgs = List("a", "b", "1", "2")
 
-  /*
-  "ExercisesService" should {
+  def library(name: String): Library =
+    Library(name, "", "")
 
+  "ExercisesService" should {
+    "not reorder libraries when there aren't any top libraries" in {
+      val libraries = List(
+        library("A lib"),
+        library("Another lib"),
+        library("Yet another lib")
+      )
+      val topLibraries = List()
+
+      val reordered = ExercisesService.reorderLibraries(topLibraries, libraries).map(_.name)
+
+      reordered must be(libraries.map(_.name))
+    }
+
+    "reorder libraries when there are top libraries" in {
+      val libraries = List(
+        library("A lib"),
+        library("Another lib"),
+        library("Yet another lib")
+      )
+      val topLibraries = List(
+        "Yet another lib",
+        "A lib",
+        "Another lib"
+      )
+
+      val reordered = ExercisesService.reorderLibraries(topLibraries, libraries).map(_.name)
+
+      reordered must be(
+        List(
+          "Yet another lib",
+          "A lib",
+          "Another lib"
+        )
+      )
+    }
+  }
+  /*
     "return at least one library via classpath discovery" in {
       val libraries = ExercisesService.libraries
       libraries must not be empty

--- a/site/server/test/com/fortysevendeg/exercises/services/ExercisesServiceSpec.scala
+++ b/site/server/test/com/fortysevendeg/exercises/services/ExercisesServiceSpec.scala
@@ -5,14 +5,11 @@
 
 package com.fortysevendeg.exercises.services
 
-import org.junit.runner._
-import org.specs2.mutable._
-import org.specs2.runner._
+import org.scalatest._
 
 import shared._
 
-@RunWith(classOf[JUnitRunner])
-class ExercisesServiceSpec extends Specification {
+class ExercisesServiceSpec extends FlatSpec with Matchers {
 
   val expectedLibrary = "stdlib"
   val expectedTestSection = "Extractors"
@@ -25,44 +22,37 @@ class ExercisesServiceSpec extends Specification {
   def library(name: String): Library =
     Library(name, "", "")
 
-  "ExercisesService" should {
-    "not reorder libraries when there aren't any top libraries" in {
-      val libraries = List(
-        library("A lib"),
-        library("Another lib"),
-        library("Yet another lib")
-      )
-      val topLibraries = List()
+  "reorderLibraries" should "not reorder libraries when there aren't any top libraries" in {
+    val libraries = List(
+      library("A lib"),
+      library("Another lib"),
+      library("Yet another lib")
+    )
+    val topLibraries = List()
 
-      val reordered = ExercisesService.reorderLibraries(topLibraries, libraries).map(_.name)
+    val reordered = ExercisesService.reorderLibraries(topLibraries, libraries).map(_.name)
 
-      reordered must be(libraries.map(_.name))
-    }
+    assert(reordered == libraries.map(_.name))
+  }
 
-    "reorder libraries when there are top libraries" in {
-      val libraries = List(
-        library("A lib"),
-        library("Another lib"),
-        library("Yet another lib")
-      )
-      val topLibraries = List(
-        "Yet another lib",
-        "A lib",
-        "Another lib"
-      )
+  "reorderLibraries" should "reorder libraries when there are top libraries" in {
+    val libraries = List(
+      library("A lib"),
+      library("Another lib"),
+      library("Yet another lib")
+    )
+    val topLibraries = List(
+      "Yet another lib",
+      "A lib",
+      "Another lib"
+    )
 
-      val reordered = ExercisesService.reorderLibraries(topLibraries, libraries).map(_.name)
+    val reordered = ExercisesService.reorderLibraries(topLibraries, libraries).map(_.name)
 
-      reordered must be(
-        List(
-          "Yet another lib",
-          "A lib",
-          "Another lib"
-        )
-      )
-    }
+    assert(reordered == List("Yet another lib", "A lib", "Another lib"))
   }
   /*
+  "ExercisesService" should {
     "return at least one library via classpath discovery" in {
       val libraries = ExercisesService.libraries
       libraries must not be empty


### PR DESCRIPTION
Added a new configuration option: `exercises.top_libraries`, that will contain an array with the names of the libraries we want to show on top in the homepage. @raulraja @juanpedromoreno please take look!