### PR TITLE
Format code samples with Scalariform

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -24,7 +24,9 @@ lazy val compiler = (project in file("compiler"))
     exportJars      := true
   )
   .settings(commonSettings: _*)
-  .settings(libraryDependencies <++= (scalaVersion)(scalaVersion =>
+  .settings(libraryDependencies ++= Seq(
+    "org.scalariform" %% "scalariform" % "0.1.8"
+  )).settings(libraryDependencies  <++= (scalaVersion)(scalaVersion =>
     compilelibs(
       Dep.scala.compiler(scalaVersion),
       Dep.cats.core)

--- a/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
+++ b/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
@@ -7,6 +7,7 @@ package com.fortysevendeg.exercises
 package compiler
 
 import scala.reflect.internal.Chars.isWhitespace
+import scalariform.formatter.{ ScalaFormatter }
 
 import cats.data.Xor
 import cats.syntax.option._
@@ -88,6 +89,24 @@ sealed trait DocRendering {
   def bodyToHtml(body: Body)(implicit skipSummary: Boolean): NodeSeq =
     body.blocks flatMap (blockToHtml(_))
 
+  def wrapCode(code: String): String =
+    s"""object Wrapper {
+     $code
+    }"""
+
+  def unwrapCode(code: String): String = {
+    code.split("\n").drop(1).dropRight(1).mkString("\n").trim
+  }
+
+  def formatCode(code: String): String = {
+    Xor.catchNonFatal(
+      ScalaFormatter.format(wrapCode(code))
+    ) match {
+      case Xor.Right(result) => unwrapCode(result)
+      case _ => code
+    }
+  }
+
   def blockToHtml(block: Block)(implicit skipSummary: Boolean): NodeSeq = block match {
     case Title(in, 1)                                        ⇒ <h3>{ inlineToHtml(in) }</h3>
     case Title(in, 2)                                        ⇒ <h4>{ inlineToHtml(in) }</h4>
@@ -96,7 +115,7 @@ sealed trait DocRendering {
     case Paragraph(Chain(Summary(in) :: Nil)) if skipSummary ⇒ Nil
     case Paragraph(in)                                       ⇒ <p>{ inlineToHtml(in) }</p>
     case Code(data) ⇒
-      <pre class={ "scala" }>{ data }</pre>
+      <pre class={ "scala" }>{ formatCode(data) }</pre>
     case UnorderedList(items) ⇒
       <ul>{ listItemsToHtml(items) }</ul>
     case OrderedList(items, listStyle) ⇒

--- a/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
+++ b/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
@@ -95,15 +95,15 @@ sealed trait DocRendering {
     }"""
 
   def unwrapCode(code: String): String = {
-    code.split("\n").drop(1).dropRight(1).mkString("\n").trim
+    code.split("\n").drop(1).dropRight(1).map(_.drop(2)).mkString("\n")
   }
 
   def formatCode(code: String): String = {
     Xor.catchNonFatal(
       ScalaFormatter.format(wrapCode(code))
     ) match {
-      case Xor.Right(result) => unwrapCode(result)
-      case _ => code
+      case Xor.Right(result) ⇒ unwrapCode(result)
+      case _                 ⇒ code
     }
   }
 


### PR DESCRIPTION
- Had to wrap the code in an `object` because the code to format has to be in an object or a class and not all examples are like that. When unwrapping I make sure to trim the leading whitespace that Scalariform adds to the body of the object.

- I run the formatting in`Xor.catchNonFatal` because the `format` method happily throws exceptions. When having a piece of non-Scala code (for example a session in the REPL) or code that can't be parsed we return it verbatim.

@raulraja @rafaparadela @juanpedromoreno @andyscott take a look please!