### PR TITLE
Change bubble up behavior of scalatest exceptions in exercises

### DIFF
--- a/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
+++ b/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/DocParser.scala
@@ -102,9 +102,9 @@ sealed trait DocRendering {
     Xor.catchNonFatal(
       ScalaFormatter.format(wrapCode(code))
     ) match {
-      case Xor.Right(result) ⇒ unwrapCode(result)
-      case _                 ⇒ code
-    }
+        case Xor.Right(result) ⇒ unwrapCode(result)
+        case _                 ⇒ code
+      }
   }
 
   def blockToHtml(block: Block)(implicit skipSummary: Boolean): NodeSeq = block match {

--- a/site/server/app/com/fortysevendeg/exercises/controllers/ApplicationController.scala
+++ b/site/server/app/com/fortysevendeg/exercises/controllers/ApplicationController.scala
@@ -18,7 +18,6 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 import play.api.routing.JavaScriptReverseRouter
 
-import shared._
 import scala.concurrent.Future
 import scalaz.concurrent.Task
 import com.fortysevendeg.exercises.services.interpreters.FreeExtensions._

--- a/site/server/app/com/fortysevendeg/exercises/controllers/ExercisesController.scala
+++ b/site/server/app/com/fortysevendeg/exercises/controllers/ExercisesController.scala
@@ -41,10 +41,7 @@ class ExercisesController(
         eval.runTask.fold(
           e ⇒ BadRequest(s"Evaluation failed : $e"),
           _.fold(
-            _.fold(
-              e ⇒ BadRequest(s"Compilation error : ${e.getMessage}"),
-              e ⇒ BadRequest(s"Runtime error : ${e.getMessage}")
-            ),
+            msg ⇒ BadRequest(msg),
             v ⇒ Ok(s"Evaluation succeeded : $v")
           )
         )

--- a/site/shared/src/main/scala/shared/Exercise.scala
+++ b/site/shared/src/main/scala/shared/Exercise.scala
@@ -44,10 +44,5 @@ case class ExerciseEvaluation(
 )
 
 object ExerciseEvaluation {
-  // TODO: create shared layer ADT for this type, or make type in
-  // runtime project available in this scope?
-  // The right projection needs to indicate a perfect run, as
-  // user progress is updated when this Xor isRight!
-  // The left projection should capture all failure scenarios.
-  type Result = Xor[Throwable, Throwable] Xor Any
+  type Result = String Xor Any
 }


### PR DESCRIPTION
This updates the core project so that exercise exceptions thrown by scalatest are handled in a special manner.

I chose to change the exercise evaluation result to a new type. The left projection is a simple error message, while the right projection is the success value. This simplifies logic in the exercise controller.