### PR TITLE
Redefines deployment settings and auth process

### DIFF
--- a/site/server/app/com/fortysevendeg/exercises/ApplicationLoader.scala
+++ b/site/server/app/com/fortysevendeg/exercises/ApplicationLoader.scala
@@ -50,7 +50,6 @@ class Components(context: Context)
         case _                           ⇒ None
       }
       (user, pass, newUrl) ← parsed
-      _ = Logger.warn("Parsed : " + List(user, pass, newUrl).mkString("\n"))
       transactor = HikariTransactor[Task](driver, newUrl, user, pass).attemptRun match {
         case \/-(t) ⇒ Some(t)
         case -\/(e) ⇒ None

--- a/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -99,8 +99,11 @@ class OAuth2Controller(
               email
             )
           ).transact(T).run match {
-              case Xor.Right(_) ⇒ Redirect(request.headers.get("referer").getOrElse("/")).withSession("oauth-token" → authToken, "user" → login)
-              case Xor.Left(_)  ⇒ InternalServerError("Failed to save user information")
+              case Xor.Right(_) ⇒ Redirect(request.headers.get("referer") match {
+                case Some(url) if !url.contains("github") ⇒ url
+                case _                                    ⇒ "/"
+              }).withSession("oauth-token" → authToken, "user" → login)
+              case Xor.Left(_) ⇒ InternalServerError("Failed to save user information")
             }
 
         }

--- a/site/server/conf/application.conf
+++ b/site/server/conf/application.conf
@@ -5,7 +5,11 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret="U3spB5^7L;EK_:<=OKxwpOJGM:0JsAyTu2pWhKsqbiGMO@tT_8voDNs:x7q=x?e<"
+play.crypto.secret="EK[Eu:ha8CEpTMYC<PjXHH9niv21un=:yQkm3QoR@GY7]gKlj^iQNaV`tNNOD6AS"
+play.crypto.secret=${?APPLICATION_SECRET}
+
+application.secret="EK[Eu:ha8CEpTMYC<PjXHH9niv21un=:yQkm3QoR@GY7]gKlj^iQNaV`tNNOD6AS"
+application.secret=${?APPLICATION_SECRET}
 
 # The application languages
 # ~~~~~
@@ -38,9 +42,9 @@ play.application.loader=com.fortysevendeg.exercises.ExercisesApplicationLoader
 
 db.default.driver=org.postgresql.Driver
 db.default.url="jdbc:postgresql://localhost:5432/scalaexercises"
-db.default.url=${?DATABASE_URL}
 db.default.username=scalaexercises_user
 db.default.password="scalaexercises_pass"
+db.default.url=${?DATABASE_URL}
 
 
 # Evolutions

--- a/site/server/conf/application.conf
+++ b/site/server/conf/application.conf
@@ -41,9 +41,6 @@ play.application.loader=com.fortysevendeg.exercises.ExercisesApplicationLoader
 #
 
 db.default.driver=org.postgresql.Driver
-db.default.url="jdbc:postgresql://localhost:5432/scalaexercises"
-db.default.username=scalaexercises_user
-db.default.password="scalaexercises_pass"
 db.default.url=${?DATABASE_URL}
 
 

--- a/site/server/conf/application.dev.conf
+++ b/site/server/conf/application.dev.conf
@@ -2,3 +2,4 @@ db.default.driver=org.postgresql.Driver
 db.default.url="jdbc:postgresql://localhost:5432/scalaexercises_dev"
 db.default.username=scalaexercises_dev_user
 db.default.password=scalaexercises_pass
+db.default.url=${?DATABASE_URL}


### PR DESCRIPTION
This PR:

- Adds several env vars for deploying in Heroku.
- Apply a condition to redirect after logging: If the referrer doesn't exist or it's github then go to home, in other case return back to the referrer. 

@raulraja @dialelo @juanpedromoreno @FPerezP Could you review please?

Notes: I have deployed these advances in Heroku, so you can try to authorize to the app again in GitHub (pay attention: [THIS LINK IS FOR REVOKING AUTHORIZATION](https://github.com/settings/applications#revoke_authorization_5bfd3164c06442db5644))

[Deployed app](http://scala-exercises.herokuapp.com/)