### PR TITLE
Fix regressions introduced by #286

### DIFF
--- a/site/content/src/main/exercises/catslib/FunctorSection.scala
+++ b/site/content/src/main/exercises/catslib/FunctorSection.scala
@@ -106,7 +106,7 @@ object FunctorSection extends FlatSpec with Matchers with exercise.Section {
     *  We can now apply the `lenOption` function to `Option` instances.
     *
     */
-  def liftingToAFunctor(res0: Int) = {
+  def liftingToAFunctor(res0: Option[Int]) = {
     val lenOption: Option[String] => Option[Int] = Functor[Option].lift(_.length)
     lenOption(Some("Hello")) should be(res0)
   }

--- a/site/server/app/com/fortysevendeg/exercises/controllers/JsonFormats.scala
+++ b/site/server/app/com/fortysevendeg/exercises/controllers/JsonFormats.scala
@@ -20,9 +20,7 @@ trait JsonFormats {
 
   implicit val librarySectionArgsWrites: Writes[LibrarySectionArgs] = Json.writes[LibrarySectionArgs]
 
-  implicit val exerciseTypeReads: Reads[ExerciseType] = (
-    (JsPath \ "exerciseType").read[String]
-  ).map(ExerciseType.fromString)
+  implicit val exerciseTypeReads: Reads[ExerciseType] = JsPath.read[String].map(ExerciseType.fromString)
 
   implicit val exerciseEvaluationReads: Reads[ExerciseEvaluation] = Json.reads[ExerciseEvaluation]
 


### PR DESCRIPTION
I implemented the JSON read wrongly, which broke the evaluation from client HTTP requests :blush: It's now fixed along with a minor fix to one of the exercises.