### PR TITLE
Cleanup Oauth code

### DIFF
--- a/site/server/app/com/fortysevendeg/exercises/controllers/ApplicationController.scala
+++ b/site/server/app/com/fortysevendeg/exercises/controllers/ApplicationController.scala
@@ -109,7 +109,8 @@ class ApplicationController(
   }
 
   def authStatus(implicit req: Request[AnyContent]): (String, String) = {
-    val scope = "user"
+    // NOTE: An empty OAuth scope indicates access to public info only
+    val scope = ""
     val state = UUID.randomUUID().toString
     val callbackUrl = com.fortysevendeg.exercises.utils.routes.OAuth2Controller.callback(None, None).absoluteURL()
     val redirectUrl = OAuth2.getAuthorizationUrl(callbackUrl, scope, state)

--- a/site/server/app/com/fortysevendeg/exercises/persistence/repositories/UserRepository.scala
+++ b/site/server/app/com/fortysevendeg/exercises/persistence/repositories/UserRepository.scala
@@ -23,8 +23,6 @@ trait UserRepository {
 
   def create(user: UserCreation.Request): ConnectionIO[UserCreation.Response]
 
-  def getOrCreate(user: UserCreation.Request): ConnectionIO[UserCreation.Response]
-
   def deleteAll(): ConnectionIO[Int]
 
   def delete(id: Long): ConnectionIO[Boolean]
@@ -58,11 +56,6 @@ class UserDoobieRepository(implicit persistence: PersistenceModule) extends User
       user ← getByLogin(login)
     } yield user.fold(UserCreation.DuplicateName.left[User])(_.right[UserCreation.DuplicateName.type])
   }
-
-  override def getOrCreate(user: UserCreation.Request): ConnectionIO[UserCreation.Response] = for {
-    maybeUser ← getByLogin(user.login)
-    theUser ← maybeUser.fold(create(user))(_.right[UserCreation.CreationError].point[ConnectionIO])
-  } yield theUser
 
   override def delete(id: Long): ConnectionIO[Boolean] = persistence.update[Long](Q.deleteById, id) map (_ > 0)
 

--- a/site/server/app/com/fortysevendeg/exercises/services/free/userops.scala
+++ b/site/server/app/com/fortysevendeg/exercises/services/free/userops.scala
@@ -5,6 +5,7 @@
 
 package com.fortysevendeg.exercises.services.free
 
+import cats.data.Xor
 import cats.free.{ Free, Inject }
 import com.fortysevendeg.exercises.persistence.domain.UserCreation
 import shared.User
@@ -36,6 +37,12 @@ class UserOps[F[_]](implicit I: Inject[UserOp, F]) {
 
   def deleteUser(user: User): Free[F, Boolean] =
     Free.inject[UserOp, F](DeleteUser(user))
+
+  def getOrCreate(user: UserCreation.Request): Free[F, UserCreation.Response] = for {
+    maybeUser ← getUserByLogin(user.login)
+    theUser ← maybeUser.fold(createUser(user))((user: User) ⇒
+      Free.pure(Xor.Right(user)))
+  } yield theUser
 }
 
 /** Default implicit based DI factory from which instances of the UserOps may be obtained

--- a/site/server/app/com/fortysevendeg/exercises/services/free/userops.scala
+++ b/site/server/app/com/fortysevendeg/exercises/services/free/userops.scala
@@ -40,8 +40,7 @@ class UserOps[F[_]](implicit I: Inject[UserOp, F]) {
 
   def getOrCreate(user: UserCreation.Request): Free[F, UserCreation.Response] = for {
     maybeUser ← getUserByLogin(user.login)
-    theUser ← maybeUser.fold(createUser(user))((user: User) ⇒
-      Free.pure(Xor.Right(user)))
+    theUser ← maybeUser.fold(createUser(user))((user: User) ⇒ Free.pure(Xor.Right(user)))
   } yield theUser
 }
 

--- a/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -84,11 +84,11 @@ class OAuth2Controller(
   def githubUserRequest(authToken: String) =
     ws.url("https://api.github.com/user").withHeaders(HeaderNames.AUTHORIZATION → s"token $authToken").get()
 
-  def fetchGitHubUser(authToken: String): Future[Option[GitHubUser]] = for {
-    response ← githubUserRequest(authToken)
-  } yield response.json.validate[GitHubUser] match {
-    case ok: JsSuccess[GitHubUser] ⇒ Some(ok.get)
-    case _                         ⇒ None
+  def fetchGitHubUser(authToken: String): Future[Option[GitHubUser]] = {
+    githubUserRequest(authToken).map(_.json.validate[GitHubUser] match {
+      case ok: JsSuccess[GitHubUser] ⇒ Some(ok.get)
+      case _                         ⇒ None
+    })
   }
 
   def getToken(code: String): Future[String] = for {

--- a/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -49,6 +49,9 @@ class OAuth2Controller(
 
   def githubTokenRequest(githubClientToken: String, githubSecretToken: String, code: String) = {
     ws.url("https://github.com/login/oauth/access_token")
+      .withHeaders(
+        "X-Oauth-Scopes" → "user:email"
+      )
       .withQueryString(
         "client_id" → githubClientToken,
         "client_secret" → githubSecretToken,

--- a/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -19,6 +19,7 @@ import play.api.libs.ws._
 import play.api.mvc.{ Action, Controller, Results, BodyParsers }
 import play.api.{ Application, Play }
 import play.api.libs.json._
+import play.api.libs.functional.syntax._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -71,7 +72,14 @@ class OAuth2Controller(
     email:     Option[String]
   )
 
-  implicit val readGithubUser: Reads[GitHubUser] = Json.reads[GitHubUser]
+  implicit val readGithubUser: Reads[GitHubUser] = (
+    (JsPath \ "login").read[String] and
+    (JsPath \ "name").readNullable[String] and
+    (JsPath \ "id").read[Long] and
+    (JsPath \ "avatar_url").read[String] and
+    (JsPath \ "html_url").read[String] and
+    (JsPath \ "email").readNullable[String]
+  )(GitHubUser.apply _)
 
   def githubUserRequest(authToken: String) =
     ws.url("https://api.github.com/user").withHeaders(HeaderNames.AUTHORIZATION → s"token $authToken").get()

--- a/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -49,9 +49,6 @@ class OAuth2Controller(
 
   def githubTokenRequest(githubClientToken: String, githubSecretToken: String, code: String) = {
     ws.url("https://github.com/login/oauth/access_token")
-      .withHeaders(
-        "X-Oauth-Scopes" → "user:email"
-      )
       .withQueryString(
         "client_id" → githubClientToken,
         "client_secret" → githubSecretToken,
@@ -141,7 +138,7 @@ class OAuth2Controller(
                   case Some(url) if !url.contains("github") ⇒ url
                   case _                                    ⇒ "/"
                 }
-              )
+              ).withSession("oauth-token" → authToken, "user" → ghUser.login)
               case Xor.Left(_) ⇒ InternalServerError("Failed to save user information")
             })
       } yield response

--- a/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/site/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -73,8 +73,11 @@ class OAuth2Controller(
 
   implicit val readGithubUser: Reads[GitHubUser] = Json.reads[GitHubUser]
 
+  def githubUserRequest(authToken: String) =
+    ws.url("https://api.github.com/user").withHeaders(HeaderNames.AUTHORIZATION → s"token $authToken").get()
+
   def fetchGitHubUser(authToken: String): Future[Option[GitHubUser]] = for {
-    response ← ws.url("https://api.github.com/user").withHeaders(HeaderNames.AUTHORIZATION → s"token $authToken").get()
+    response ← githubUserRequest(authToken)
   } yield response.json.validate[GitHubUser] match {
     case ok: JsSuccess[GitHubUser] ⇒ Some(ok.get)
     case _                         ⇒ None

--- a/site/server/test/com/fortysevendeg/exercises/persistence/repositories/UserRepositorySpec.scala
+++ b/site/server/test/com/fortysevendeg/exercises/persistence/repositories/UserRepositorySpec.scala
@@ -95,25 +95,4 @@ class UserRepositorySpec
       }) shouldBe true
     }
   }
-
-  property("`getOrCreate` retrieves a user if already created") {
-    forAll { newUser: Request ⇒
-      repository.deleteAll().transact(transactor).run
-
-      repository.create(newUser).transact(transactor).run
-      repository.getOrCreate(newUser).transact(transactor).run
-
-      repository.all.transact(transactor).run.length shouldBe 1
-    }
-  }
-
-  property("`getOrCreate` creates a user if it's not already created") {
-    forAll { newUser: Request ⇒
-      repository.deleteAll().transact(transactor).run
-
-      repository.getOrCreate(newUser).transact(transactor).run
-
-      repository.all.transact(transactor).run.length shouldBe 1
-    }
-  }
 }


### PR DESCRIPTION
- [x] Implemented OAuth code in terms of user algebra instead of repository, moving the `getOrCreate` function to the `UserOps` primitives.
- [x] Cleaned up code in the OAuth controller, separating GitHub communication in their own methods. In the future we may want to split this further into a propper GH client, when we use GitHub data for showing contributors.
- [x] Improved the JSON parsing, it will no longer fail at runtime.
- [x] Changed OAuth scope so we have only access to data that is public

@raulraja @rafaparadela @juanpedromoreno take a look and let me know if something is missing.